### PR TITLE
♻️🐛 [Trusted Types] Make createExtensionScript Trusted Types compatible

### DIFF
--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -155,7 +155,26 @@ export function createExtensionScript(win, extensionId, version) {
     version,
     getMode(win).localDev
   );
-  scriptElement.src = scriptSrc;
+
+  if (self.trustedTypes && self.trustedTypes.createPolicy) {
+    const policy = self.trustedTypes.createPolicy(
+      'extension-script#createExtensionScript',
+      {
+        createScriptURL: function (url) {
+          // Only allow trusted URLs
+          const urlObject = new URL(url);
+          if (urlObject.host === 'cdn.ampproject.org') {
+            return url;
+          } else {
+            return '';
+          }
+        },
+      }
+    );
+    scriptElement.src = policy.createScriptURL(scriptSrc);
+  } else {
+    scriptElement.src = scriptSrc;
+  }
   return scriptElement;
 }
 


### PR DESCRIPTION
This change updates AMP's createExtensionScript function to be [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compatible, partial fix to https://github.com/ampproject/amphtml/issues/37297. The function was directly setting the scriptElement.src to some variable url. This url is expected to fall under the cdn so we can restrict the host the url takes on to cdn.ampproject.org and return the url as being a TrustedScriptUrl.