### PR TITLE
♻️🐛 [Trusted Types] Make AmpWorker Trusted Types compatible

### DIFF
--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -103,7 +103,19 @@ class AmpWorker {
           type: 'text/javascript',
         });
         const blobUrl = win.URL.createObjectURL(blob);
-        this.worker_ = new win.Worker(blobUrl);
+        if (self.trustedTypes && self.trustedTypes.createPolicy) {
+          const policy = self.trustedTypes.createPolicy(
+            'amp-worker#constructor',
+            {
+              createScriptURL: function (url) {
+                return url;
+              },
+            }
+          );
+          this.worker_ = new win.Worker(policy.createScriptURL(blobUrl));
+        } else {
+          this.worker_ = new win.Worker(blobUrl);
+        }
         this.worker_.onmessage = this.receiveMessage_.bind(this);
       });
 

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -77,7 +77,7 @@ class AmpWorker {
     if (self.trustedTypes && self.trustedTypes.createPolicy) {
       const policy = self.trustedTypes.createPolicy('amp-worker#fetchUrl', {
         createScriptURL: function (url) {
-          // Only allow trusted URLs
+          // Only allow the correct webworker url to pass through
           const regexURL = new RegExp(
             // eslint-disable-next-line local/no-forbidden-terms
             '^https://([a-zA-Z0-9_-]+.)?cdn.ampproject.org(/.*)?$'


### PR DESCRIPTION
This change updates AMP's AmpWorker constructor to be [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compatible, partial fix to https://github.com/ampproject/amphtml/issues/37297. It seems that the Blob is being created to execute https://cdn.ampproject.org/ww.js whose entry point is https://github.com/ampproject/amphtml/blob/main/src/web-worker/web-worker.js. So amp-worker.js is fetching web-worker.js as raw text, turning it into a Blob instance, which in turn gets created into a Worker instance and its being used to offload amp-bind work to a worker dom so that the work is off the main thread.

The violation here is caused by blobUrl not being a trustedScript. blobUrl is created using createObjectURL(blob). createObjectURL only outputs url that are as dangerous as their contents ([URL: createObjectURL() static method - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static)) so we need to ensure that blob is safe. blob is created using text and url. url is created using calculateEntryPointScriptUrl from [extension-script.js](http://extension-script.js/) which we’ve designated as safe as long as it has the cdn domain. The url points to the [ww.js](http://ww.js/) file as it is constructed. text is created by fetching the content of the url, or the [ww.js](http://ww.js/) file. So the blobUrl should then, by extension, be safe.