### PR TITLE
♻️🐛 [Trusted Types] Make DOMPurify wrapper and serializeHtml_ function Trusted Types compatible

### DIFF
--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -9,6 +9,7 @@ import {
   sanitizeHtml,
   sanitizeTagsForTripleMustache,
 } from '../../../src/sanitizer';
+import {Purifier} from '#purifier';
 
 const TAG = 'amp-mustache';
 
@@ -143,8 +144,8 @@ export class AmpMustache extends BaseTemplate {
   serializeHtml_(html) {
     const doc = this.win.document;
     const root = doc.createElement('div');
-    const sanitized = sanitizeHtml(html, doc);
-    root./*OK*/ innerHTML = sanitized;
+    const purifier = new Purifier(doc, {'RETURN_DOM': false,'RETURN_TRUSTED_TYPE':true}, null, false);
+    root./*OK*/ innerHTML = purifier.purifyHtml(html);
     return this.tryUnwrap(root);
   }
 }

--- a/src/purifier/index.d.ts
+++ b/src/purifier/index.d.ts
@@ -8,7 +8,8 @@ export class Purifier {
   constructor(
     doc: Document,
     opt_config?: DOMPurify.Config,
-    opt_attrRewrite?: AttributeRewriterDef
+    opt_attrRewrite?: AttributeRewriterDef,
+    opt_useStandardConfig?: boolean
   );
 
   purifyHtml(dirty: string): HTMLElement;

--- a/src/purifier/index.js
+++ b/src/purifier/index.js
@@ -56,8 +56,9 @@ export class Purifier {
    * @param {!Document} doc
    * @param {!JsonObject=} opt_config
    * @param {!AttributeRewriterDef=} opt_attrRewrite
+   * @param {bool} opt_useStandardConfig
    */
-  constructor(doc, opt_config, opt_attrRewrite) {
+  constructor(doc, opt_config, opt_attrRewrite, useStandardConfig = true) {
     /** @private {!Document} */
     this.doc_ = doc;
 
@@ -73,7 +74,7 @@ export class Purifier {
     /** @private {!DomPurifyDef} */
     this.domPurifyTriple_ = purify(self);
 
-    const config = Object.assign(opt_config || {}, standardPurifyConfig());
+    const config = useStandardConfig ? Object.assign(opt_config || {}, standardPurifyConfig()): opt_config;
     this.domPurify_.setConfig(config);
     this.addPurifyHooks_(this.domPurify_, opt_attrRewrite);
 


### PR DESCRIPTION
This change updates AMP's dompurify wrapper and serializeHtml_ function to be [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compatible, partial fix to https://github.com/ampproject/amphtml/issues/37297. The DOMPurify wrapper used within AMP did not allow for overriding the standardConfigs so a flag was added to the constructor to override the standard config. This allowed us to use the DOMPurify wrapper to sanitize html elements in the serializeHtml_ function.