### PR TITLE
♻️🐛 [Trusted Types] Make loadScript, writeScript, and addAttributesToElement Trusted Types compatible

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -56,6 +56,35 @@ export function run(id, win, data) {
   fn(win, data);
 }
 
+function assertValidJustification(justification) {
+  if (typeof justification !== 'string' || justification.trim() === '') {
+    let errMsg =
+      'Calls to uncheckedconversion functions must go through security review.';
+    errMsg += ' A justification must be provided to capture what security' +
+      ' assumptions are being made.';
+    throw new Error(errMsg);
+  }
+}
+
+export function scriptURLSafeByReview(html, justification) {
+  assertValidJustification(justification);
+
+  if (self.trustedTypes && self.trustedTypes.createPolicy) {
+    const policy = self.trustedTypes.createPolicy(
+      '3p#scriptSafeByReview',
+      {
+        createScriptURL: function (html) {
+          // This policy is only to be used for trusted inputs that do not involve unsanitized user inputs.
+          return html;
+        },
+      }
+    );
+    return policy.createScriptURL(html);
+  } else {
+    return html;
+  }
+};
+
 /**
  * Synchronously load the given script URL. Only use this if you need a sync
  * load. Otherwise use {@link loadScript}.

--- a/3p/beopinion.js
+++ b/3p/beopinion.js
@@ -16,7 +16,7 @@
 
 import {setStyles} from '#core/dom/style';
 
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 /**
  * Produces the Twitter API object for the passed in callback. If the current
@@ -26,7 +26,7 @@ import {loadScript} from './3p';
  * @param {!Window} global
  */
 function getBeOpinion(global) {
-  loadScript(global, 'https://widget.beop.io/sdk.js', function () {});
+  loadScript(global, scriptURLSafeByReview('https://widget.beop.io/sdk.js', 'legacy'), function () {});
 }
 
 /**

--- a/3p/bodymovinanimation.js
+++ b/3p/bodymovinanimation.js
@@ -4,15 +4,15 @@ import {parseJson} from '#core/types/object/json';
 
 import {getData} from '#utils/event-helper';
 
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 const libSourceUrl = {
   'canvas':
-    'https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.7.6/lottie_canvas.min.js',
+    scriptURLSafeByReview('https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.7.6/lottie_canvas.min.js', 'legacy'),
   'html':
-    'https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.7.6/lottie_html.min.js',
+    scriptURLSafeByReview('https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.7.6/lottie_html.min.js', 'legacy'),
   'svg':
-    'https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.7.6/lottie_svg.min.js',
+    scriptURLSafeByReview('https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.7.6/lottie_svg.min.js', 'legacy'),
 };
 
 /**

--- a/3p/embedly.js
+++ b/3p/embedly.js
@@ -1,13 +1,13 @@
 import {setStyle} from '#core/dom/style';
 import {hasOwn} from '#core/types/object';
 
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 /**
  * Embedly platform library url to create cards.
  * @const {string}
  */
-const EMBEDLY_SDK_URL = 'https://cdn.embedly.com/widgets/platform.js';
+const EMBEDLY_SDK_URL = scriptURLSafeByReview('https://cdn.embedly.com/widgets/platform.js', 'legacy');
 
 /**
  * Event name emitted by embedly's SDK.

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -4,7 +4,7 @@ import {dashToUnderline} from '#core/types/string';
 
 import {devAssert} from '#utils/log';
 
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 /** @const @enum {string} */
 export const FacebookEmbedType = {
@@ -31,7 +31,7 @@ export const FacebookEmbedType = {
 function getFacebookSdk(global, cb, locale) {
   loadScript(
     global,
-    'https://connect.facebook.net/' + locale + '/sdk.js',
+    scriptURLSafeByReview('https://connect.facebook.net/' + locale + '/sdk.js', 'legacy'),
     () => {
       cb(global.FB);
     }

--- a/3p/recaptcha.js
+++ b/3p/recaptcha.js
@@ -12,7 +12,7 @@ import {
   user,
 } from '#utils/log';
 
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 import {IframeMessagingClient} from './iframe-messaging-client';
 
 import {isProxyOrigin, parseUrlDeprecated} from '../src/url';
@@ -101,7 +101,7 @@ export function initRecaptcha(recaptchaApiBaseUrl = RECAPTCHA_API_URL) {
 
   loadScript(
     win,
-    recaptchaApiUrl,
+    scriptURLSafeByReview(recaptchaApiUrl, 'legacy'),
     function () {
       const {grecaptcha} = win;
 

--- a/3p/reddit.js
+++ b/3p/reddit.js
@@ -1,4 +1,4 @@
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 /**
  * Get the correct script for the container.
@@ -53,10 +53,10 @@ export function reddit(global, data) {
   // Post and comment embeds are handled totally differently.
   if (embedtype === 'post') {
     container = getPostContainer(global);
-    scriptSource = 'https://embed.redditmedia.com/widgets/platform.js';
+    scriptSource = scriptURLSafeByReview('https://embed.redditmedia.com/widgets/platform.js', 'legacy');
   } else if (embedtype === 'comment') {
     container = getCommentContainer(global, data);
-    scriptSource = 'https://www.redditstatic.com/comment-embed.js';
+    scriptSource = scriptURLSafeByReview('https://www.redditstatic.com/comment-embed.js','legacy');
   }
 
   const link = global.document.createElement('a');

--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -2,7 +2,7 @@
 
 import {setStyles} from '#core/dom/style';
 
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 /**
  * Produces the Twitter API object for the passed in callback. If the current
@@ -13,7 +13,7 @@ import {loadScript} from './3p';
  * @param {function(!Object)} cb
  */
 function getTwttr(global, cb) {
-  loadScript(global, 'https://platform.twitter.com/widgets.js', () => {
+  loadScript(global, scriptURLSafeByReview('https://platform.twitter.com/widgets.js', 'legacy'), () => {
     cb(global.twttr);
   });
   // Temporarily disabled the code sharing between frames.

--- a/3p/viqeoplayer.js
+++ b/3p/viqeoplayer.js
@@ -3,7 +3,7 @@ import {tryDecodeUriComponent} from '#core/types/string/url';
 
 import {getData} from '#utils/event-helper';
 
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 /**
  * @param {Window} global
@@ -106,5 +106,5 @@ export function viqeoplayer(global) {
       : 'https://static.viqeo.tv/js/vq_player_init.js?branch=dev1');
 
   global['onViqeoLoad'] = (VIQEO) => viqeoPlayerInitLoaded(global, VIQEO);
-  loadScript(global, scriptPlayerInit);
+  loadScript(global, scriptURLSafeByReview(scriptPlayerInit, 'legacy'));
 }

--- a/3p/yotpo.js
+++ b/3p/yotpo.js
@@ -1,4 +1,4 @@
-import {loadScript} from './3p';
+import {loadScript, scriptURLSafeByReview} from './3p';
 
 /**
  * Get the correct script for the container.
@@ -287,7 +287,7 @@ export function yotpo(global, data) {
   let cssLoaded = false;
   let batchLoaded = false;
   const scriptSource =
-    'https://staticw2.yotpo.com/' + data.appKey + '/widget.js';
+    scriptURLSafeByReview('https://staticw2.yotpo.com/' + data.appKey + '/widget.js', 'legacy');
   getContainerScript(
     global,
     scriptSource,

--- a/ads/google/ima/ima-video.js
+++ b/ads/google/ima/ima-video.js
@@ -1,4 +1,4 @@
-import {loadScript} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview} from '#3p/3p';
 
 import {
   CONSENT_POLICY_STATE,
@@ -449,7 +449,7 @@ export function imaVideo(global, data) {
     // Set-up code that can't run until the IMA lib loads.
     loadScript(
       /** @type {!Window} */ (global),
-      'https://imasdk.googleapis.com/js/sdkloader/ima3.js',
+      scriptURLSafeByReview('https://imasdk.googleapis.com/js/sdkloader/ima3.js', 'legacy'),
       () => onImaLoadSuccess(global, data),
       onImaLoadFail
     );

--- a/ads/vendors/1wo.js
+++ b/ads/vendors/1wo.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -8,7 +8,7 @@ export function _1wo(global, data) {
   validateData(data, ['src', 'owoType', 'owoCode', 'owoMode']);
   const {src} = data;
   createContainer(global, data);
-  loadScript(global, src);
+  loadScript(global, scriptURLSafeByReview(src, 'legacy'));
 }
 
 /**

--- a/ads/vendors/24smi.js
+++ b/ads/vendors/24smi.js
@@ -1,7 +1,7 @@
-import {loadScript, validateData, validateSrcPrefix} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData, validateSrcPrefix} from '#3p/3p';
 
 const jsnPrefix = 'https://jsn.24smi.net/';
-const smiJs = `${jsnPrefix}smi.js`;
+const smiJs = scriptURLSafeByReview(`${jsnPrefix}smi.js`,'legacy');
 
 /**
  * @param {!Window} global

--- a/ads/vendors/4wmarketplace.js
+++ b/ads/vendors/4wmarketplace.js
@@ -1,4 +1,4 @@
-import {loadScript} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -30,7 +30,7 @@ export function _4wmarketplace(global, data) {
         amp: 1,
       });
     });
-    loadScript($4wm, 'https://static-adsr.4wnetwork.com/js/fwloader.js', () => {
+    loadScript($4wm, scriptURLSafeByReview('https://static-adsr.4wnetwork.com/js/fwloader.js', 'legacy'), () => {
       window.addEventListener('message', (e) => {
         if (
           e.data.message == 'RESIZE_AMP' &&
@@ -58,7 +58,7 @@ export function _4wmarketplace(global, data) {
 
     $4wm.objFw = [];
     $4wm.objFw.push(obj);
-    loadScript($4wm, 'https://static.4wnetwork.com/js/sdk.min.js', () => {
+    loadScript($4wm, scriptURLSafeByReview('https://static.4wnetwork.com/js/sdk.min.js', 'legacy'), () => {
       window.addEventListener('message', (e) => {
         if (
           e.data.message == 'RESIZE_AMP' &&

--- a/ads/vendors/a9.js
+++ b/ads/vendors/a9.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData, writeScript} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData, writeScript} from '#3p/3p';
 
 import {hasOwn} from '#core/types/object';
 import {parseJson} from '#core/types/object/json';
@@ -111,6 +111,7 @@ function getURL(data) {
 function loadRecTag(global, data, publisherUrl) {
   let url = getURL(data);
   url += '&adInstanceId=' + data['adinstanceid'];
+  url = scriptURLSafeByReview(url);
   global['amzn_assoc_URL'] = publisherUrl;
 
   if (data['recomtype'] === 'sync') {

--- a/ads/vendors/adagio.js
+++ b/ads/vendors/adagio.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -12,5 +12,5 @@ export function adagio(global, data) {
   $neodata._adagio = {};
   $neodata._adagio.amp = data;
 
-  loadScript($neodata, 'https://js-ssl.neodatagroup.com/adagio_amp.js');
+  loadScript($neodata, scriptURLSafeByReview('https://js-ssl.neodatagroup.com/adagio_amp.js', 'legacy'));
 }

--- a/ads/vendors/adbutler.js
+++ b/ads/vendors/adbutler.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -41,5 +41,5 @@ export function adbutler(global, data) {
       click: 'CLICK_MACRO_PLACEHOLDER',
     },
   });
-  loadScript(global, 'https://servedbyadbutler.com/app.js');
+  loadScript(global, scriptURLSafeByReview('https://servedbyadbutler.com/app.js', 'legacy'));
 }

--- a/ads/vendors/adfox.js
+++ b/ads/vendors/adfox.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -6,7 +6,7 @@ import {loadScript, validateData} from '#3p/3p';
  */
 export function adfox(global, data) {
   validateData(data, ['adfoxParams', 'ownerId']);
-  loadScript(global, 'https://yandex.ru/ads/system/context.js', () =>
+  loadScript(global, scriptURLSafeByReview('https://yandex.ru/ads/system/context.js', 'legacy'), () =>
     renderAdFox(global, data)
   );
 }

--- a/ads/vendors/adincube.js
+++ b/ads/vendors/adincube.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 import {hasOwn} from '#core/types/object';
 
@@ -24,7 +24,7 @@ export function adincube(global, data) {
     url += parseParams(data['params']);
   }
 
-  loadScript(global, url);
+  loadScript(global, scriptURLSafeByReview(url, 'legacy'));
 }
 
 /**

--- a/ads/vendors/admanmedia.js
+++ b/ads/vendors/admanmedia.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -10,7 +10,7 @@ export function admanmedia(global, data) {
   const encodedId = encodeURIComponent(data.id);
   loadScript(
     global,
-    `https://pub.admanmedia.com/go?id=${encodedId}`,
+    scriptURLSafeByReview(`https://pub.admanmedia.com/go?id=${encodedId}`, 'legacy'),
     () => {
       global.context.renderStart();
     },

--- a/ads/vendors/adnuntius.js
+++ b/ads/vendors/adnuntius.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -7,7 +7,7 @@ import {loadScript, validateData} from '#3p/3p';
 export function adnuntius(global, data) {
   validateData(data, ['auId']);
 
-  loadScript(global, 'https://cdn.adnuntius.com/adn.js', () => {
+  loadScript(global, scriptURLSafeByReview('https://cdn.adnuntius.com/adn.js', 'legacy'), () => {
     global.adn = global.adn || {};
     global.adn.calls = global.adn.calls || [];
     global.adn.calls.push(() => {

--- a/ads/vendors/adplugg.js
+++ b/ads/vendors/adplugg.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 import {hasOwn} from '#core/types/object';
 
@@ -9,7 +9,7 @@ import {hasOwn} from '#core/types/object';
  */
 export function adplugg(global, data) {
   // Load ad.js
-  loadScript(global, 'https://www.adplugg.com/serve/js/ad.js');
+  loadScript(global, scriptURLSafeByReview('https://www.adplugg.com/serve/js/ad.js', 'legacy'));
 
   // Validate the amp-ad attributes.
   validateData(

--- a/ads/vendors/adpushup.js
+++ b/ads/vendors/adpushup.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -12,13 +12,13 @@ export function adpushup(global, data) {
   );
   loadScript(
     global,
-    'https://securepubads.g.doubleclick.net/tag/js/gpt.js',
+    scriptURLSafeByReview('https://securepubads.g.doubleclick.net/tag/js/gpt.js', 'legacy'),
     () => {
       const domain =
         data.loadalternate === 'true'
           ? 'https://assets.adpushup.com/'
           : 'https://cdn.adpushup.com/';
-      const url = domain + data.siteid + '/amp.js';
+      const url = scriptURLSafeByReview(domain + data.siteid + '/amp.js', 'legacy');
       loadScript(global, url, () => {
         window.adpushup.initAmp(
           global,

--- a/ads/vendors/ads2bid.js
+++ b/ads/vendors/ads2bid.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -7,7 +7,7 @@ import {loadScript, validateData} from '#3p/3p';
 export function ads2bid(global, data) {
   validateData(data, ['blockId', 'siteId', 'src']);
   const {blockId, siteId, src} = data;
-  const url = src + `/html/amp?site_id=${siteId}&blocks=${blockId}`;
+  const url = scriptURLSafeByReview(src + `/html/amp?site_id=${siteId}&blocks=${blockId}`, 'legacy');
   createContainer(global);
   loadScript(global, url);
 }

--- a/ads/vendors/adskeeper.js
+++ b/ads/vendors/adskeeper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -57,5 +57,5 @@ export function adskeeper(global, data) {
     });
   });
 
-  loadScript(global, data.url || url);
+  loadScript(global, scriptURLSafeByReview(data.url || url, 'legacy'));
 }

--- a/ads/vendors/adsloom.js
+++ b/ads/vendors/adsloom.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -13,6 +13,6 @@ export function adsloom(global, data) {
   };
   loadScript(
     global,
-    'https://adsloomwebservices.adsloom.com/scripts/amp-loader.js'
+    scriptURLSafeByReview('https://adsloomwebservices.adsloom.com/scripts/amp-loader.js', 'legacy')
   );
 }

--- a/ads/vendors/adstir.js
+++ b/ads/vendors/adstir.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -19,5 +19,5 @@ export function adstir(global, data) {
   d.setAttribute('data-origin', global.context.location.href);
   global.document.getElementById('c').appendChild(d);
 
-  loadScript(global, 'https://js.ad-stir.com/js/adstir_async.js');
+  loadScript(global, scriptURLSafeByReview('https://js.ad-stir.com/js/adstir_async.js', 'legacy'));
 }

--- a/ads/vendors/adstyle.js
+++ b/ads/vendors/adstyle.js
@@ -1,4 +1,4 @@
-import {loadScript, validateData} from '#3p/3p';
+import {loadScript, scriptURLSafeByReview, validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
@@ -17,7 +17,7 @@ export function adstyle(global, data) {
 
   global._adstyle.widgetIds.push(data.widget);
 
-  const url = 'https://widgets.ad.style/amp.js';
+  const url = scriptURLSafeByReview('https://widgets.ad.style/amp.js', 'legacy');
 
   window.context.observeIntersection(function (changes) {
     /** @type {!Array} */ (changes).forEach(function (c) {

--- a/build-system/test-configs/karma.conf.js
+++ b/build-system/test-configs/karma.conf.js
@@ -84,7 +84,13 @@ module.exports = {
     testServerPort: TEST_SERVER_PORT,
   },
 
-  singleRun: true,
+  customHeaders: [{
+    match: '.*',
+    name: 'Content-Security-Policy',
+    value: `require-trusted-types-for 'script'; report-uri /cspreport`,
+  }],
+
+  singleRun: false,
   captureTimeout: 4 * 60 * 1000,
   failOnEmptyTestSuite: false,
 


### PR DESCRIPTION
This change updates AMP's loadScript, writeScript, and addAttributesToElement functions to be [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compatible, partial fix to https://github.com/ampproject/amphtml/issues/37297. The functions were acting as wrappers for some functionality for the setAttribute function and were used extensively throughout the codebase with a variety of different values so it made sense to implement legacy conversions to amend the TT violations.